### PR TITLE
Bug fix | Beta Graph API to fetch user profile note is failing

### DIFF
--- a/Source/Microsoft.Teams.Apps.NewHireOnboarding/Helpers/GraphApiHelper.cs
+++ b/Source/Microsoft.Teams.Apps.NewHireOnboarding/Helpers/GraphApiHelper.cs
@@ -174,20 +174,31 @@ namespace Microsoft.Teams.Apps.NewHireOnboarding.Helpers
             }
 
             var graphClient = this.GetGraphServiceClientBeta(token);
-            var notes = await graphClient
-                .Users[userId]
-                .Profile
-                .Notes
-                .Request()
-                .WithMaxRetry(GraphConstants.MaxRetry)
-                .GetAsync();
-
-            if (notes == null)
+            try
             {
+                var notes = await graphClient
+                    .Users[userId]
+                    .Profile
+                    .Notes
+                    .Request()
+                    .WithMaxRetry(GraphConstants.MaxRetry)
+                    .GetAsync();
+
+                if (notes == null)
+                {
+                    return null;
+                }
+
+                return notes.First().Detail?.Content;
+            }
+#pragma warning disable CA1031 // Catching general exceptions that might arise during Microsoft Graph API beta call failure to get user profile notes.
+            catch (Exception ex)
+#pragma warning restore CA1031 // Catching general exceptions that might arise during Microsoft Graph API beta call failure to get user profile notes.
+            {
+                this.logger.LogError(ex, $"Failed to get user profile note for user: {userId}.");
+
                 return null;
             }
-
-            return notes.First().Detail?.Content;
         }
 
         /// <summary>

--- a/Source/Microsoft.Teams.Apps.NewHireOnboarding/Helpers/GraphApiHelper.cs
+++ b/Source/Microsoft.Teams.Apps.NewHireOnboarding/Helpers/GraphApiHelper.cs
@@ -173,27 +173,19 @@ namespace Microsoft.Teams.Apps.NewHireOnboarding.Helpers
                 throw new ArgumentNullException(nameof(userId));
             }
 
-            var graphClient = this.GetGraphServiceClientBeta(token);
+            var graphClient = this.GetGraphServiceClient(token);
             try
             {
                 var notes = await graphClient
                     .Users[userId]
-                    .Profile
-                    .Notes
                     .Request()
+                    .Select("aboutMe")
                     .WithMaxRetry(GraphConstants.MaxRetry)
                     .GetAsync();
 
-                if (notes == null)
-                {
-                    return null;
-                }
-
-                return notes.First().Detail?.Content;
+                return notes?.AboutMe;
             }
-#pragma warning disable CA1031 // Catching general exceptions that might arise during Microsoft Graph API beta call failure to get user profile notes.
-            catch (Exception ex)
-#pragma warning restore CA1031 // Catching general exceptions that might arise during Microsoft Graph API beta call failure to get user profile notes.
+            catch (ServiceException ex)
             {
                 this.logger.LogError(ex, $"Failed to get user profile note for user: {userId}.");
 


### PR DESCRIPTION
Fix: The Graph API endpoint "https://graph.microsoft.com/beta/me/profile" is failing to fetch user notes information using delegated permissions. As a work around, the call logs the exception and return null. The changes are made in GraphApiHelper.


