### PR TITLE
ARM deployment file fix to refer main branch

### DIFF
--- a/Deployment/azuredeploy.json
+++ b/Deployment/azuredeploy.json
@@ -148,7 +148,7 @@
     "appIconUrl": {
       "type": "string",
       "minLength": 1,
-      "defaultValue": "https://raw.githubusercontent.com/OfficeDev/microsoft-teams-apps-newemployeeonboarding/master/Manifest/color.png",
+      "defaultValue": "https://raw.githubusercontent.com/OfficeDev/microsoft-teams-apps-newemployeeonboarding/main/Manifest/color.png",
       "metadata": {
         "description": "The link to the icon for the app. It must resolve to a PNG file."
       }
@@ -210,7 +210,7 @@
       "metadata": {
         "description": "The branch of the GitHub repository to deploy."
       },
-      "defaultValue": "master"
+      "defaultValue": "main"
     }
   },
   "variables": {


### PR DESCRIPTION
Fix: ARM deployment file is referring to master branch which should be main branch as per latest GitHub changes. This is causing failure in default ARM template and installer has to manually change the branch name. Fixed the default value from master to main.