### PR TITLE
ARM templates for GCC hybrid deployment

### DIFF
--- a/Deployment/GCC/botazuredeploy.json
+++ b/Deployment/GCC/botazuredeploy.json
@@ -1,0 +1,126 @@
+{
+   "$schema":"https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+   "contentVersion":"1.0.0.0",
+   "parameters":{
+      "baseResourceName":{
+         "type":"string",
+         "minLength":1,
+         "metadata":{
+            "description":"The base name to use for the resources that will be provisioned."
+         }
+      },
+      "botClientId":{
+         "type":"string",
+         "minLength":36,
+         "maxLength":36,
+         "metadata":{
+            "description":"The client ID of the bot Azure Active Directory app, e.g., 742e4567-e89b-12d3-a456-426655443586."
+         }
+      },
+      "botClientSecret":{
+         "type":"securestring",
+         "minLength":1,
+         "metadata":{
+            "description":"The client secret of the bot Azure Active Directory app."
+         }
+      },
+      "location":{
+         "type":"string",
+         "defaultValue":"[resourceGroup().location]",
+         "metadata":{
+            "description":"Location for all resources."
+         }
+      },
+      "appDisplayName":{
+         "type":"string",
+         "minLength":1,
+         "defaultValue":"New Employee Onboarding",
+         "metadata":{
+            "description":"App display name."
+         }
+      },
+      "appDescription":{
+         "type":"string",
+         "minLength":1,
+         "defaultValue":"Customized App Neo (New Employee Orientation) for their organization where the new hires can successfully do their onboarding journey via Teams.",
+         "metadata":{
+            "description":"App description."
+         }
+      },
+      "appIconUrl":{
+         "type":"string",
+         "minLength":1,
+         "defaultValue":"https://raw.githubusercontent.com/OfficeDev/microsoft-teams-apps-newemployeeonboarding/main/Manifest/color.png",
+         "metadata":{
+            "description":"The link to the icon for the app. It must resolve to a PNG file."
+         }
+      }
+   },
+   "variables":{
+      "botName":"[parameters('baseResourceName')]",
+      "botAppName":"[parameters('baseResourceName')]",
+      "botAppDomain":"[concat(variables('botAppName'), '.azurewebsites.net')]",
+      "botAppUrl":"[concat('https://', variables('botAppDomain'))]",
+      "botAppInsightsName":"[parameters('baseResourceName')]"
+   },
+   "resources":[
+      {
+         "apiVersion":"2015-05-01",
+         "name":"[variables('botAppInsightsName')]",
+         "type":"Microsoft.Insights/components",
+         "location":"[parameters('location')]",
+         "tags":{
+            "[concat('hidden-link:', resourceGroup().id, '/providers/Microsoft.Web/sites/', variables('botAppName'))]":"Resource"
+         },
+         "properties":{
+            "Application_Type":"web",
+            "Request_Source":"rest"
+         }
+      },
+      {
+         "apiVersion":"2018-07-12",
+         "kind":"sdk",
+         "location":"global",
+         "name":"[variables('botName')]",
+         "properties":{
+            "displayName":"[parameters('appDisplayName')]",
+            "description":"[parameters('appDescription')]",
+            "iconUrl":"[parameters('appIconUrl')]",
+            "msaAppId":"[parameters('botClientId')]",
+            "endpoint":"[concat(variables('botAppUrl'), '/api/messages')]",
+            "developerAppInsightKey":"[reference(resourceId('Microsoft.Insights/components', variables('botAppInsightsName')), '2015-05-01').InstrumentationKey]"
+         },
+         "resources":[
+            {
+               "name":"[concat(variables('botName'), '/MsTeamsChannel')]",
+               "type":"Microsoft.BotService/botServices/channels",
+               "apiVersion":"2018-07-12",
+               "location":"global",
+               "sku":{
+                  "name":"F0"
+               },
+               "properties":{
+                  "channelName":"MsTeamsChannel",
+                  "location":"global",
+                  "properties":{
+                     "isEnabled":true
+                  }
+               },
+               "dependsOn":[
+                  "[concat('Microsoft.BotService/botServices/', variables('botName'))]"
+               ]
+            }
+         ],
+         "sku":{
+            "name":"F0"
+         },
+         "type":"Microsoft.BotService/botServices"
+      }
+   ],
+   "outputs":{
+      "botId":{
+         "type":"String",
+         "value":"[parameters('botClientId')]"
+      }
+   }
+}

--- a/Deployment/GCC/otherresourcesazuredeploy.json
+++ b/Deployment/GCC/otherresourcesazuredeploy.json
@@ -1,0 +1,511 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "baseResourceName": {
+      "type": "string",
+      "minLength": 1,
+      "metadata": {
+        "description": "The base name to use for the resources that will be provisioned."
+      }
+    },
+    "botClientId": {
+      "type": "string",
+      "minLength": 36,
+      "maxLength": 36,
+      "metadata": {
+        "description": "The client ID of the bot Azure Active Directory app, e.g., 742e4567-e89b-12d3-a456-426655443586."
+      }
+    },
+    "botClientSecret": {
+      "type": "securestring",
+      "minLength": 1,
+      "metadata": {
+        "description": "The client secret of the bot Azure Active Directory app."
+      }
+    },
+    "manifestId": {
+      "type": "string",
+      "minLength": 36,
+      "maxLength": 36,
+      "defaultValue": "1c412988-ba71-40af-8b9b-b5be27fe3a6f",
+      "metadata": {
+        "description": "Manifest Id (Required for deeplinking). This needs to be same as manifest Id provided in manifest.json file inside Manifest folder."
+      }
+    },
+    "humanResourceTeamLink": {
+      "type": "string",
+      "minLength": 1,
+      "metadata": {
+        "description": "Human resource team URL in Microsoft Teams, to which the app will send feedback notifications. This URL starts with https://teams.microsoft.com/l/team/ ."
+      }
+    },
+    "siteName": {
+      "type": "string",
+      "minLength": 1,
+      "metadata": {
+        "description": "New employee onboarding SharePoint site name."
+      }
+    },
+    "newHireCheckListName": {
+      "type": "string",
+      "minLength": 1,
+      "metadata": {
+        "description": "SharePoint site new hire check list name."
+      }
+    },
+    "siteTenantName": {
+      "type": "string",
+      "minLength": 1,
+      "metadata": {
+        "description": "SharePoint site tenant name. e.g. This URL looks like https://contoso.sharepoint.com  where contoso is the tenant name."
+      }
+    },
+    "shareFeedbackFormUrl": {
+      "type": "string",
+      "minLength": 1,
+      "metadata": {
+        "description": "Share feedback url from SharePoint."
+      }
+    },
+    "completeLearningPlanUrl": {
+      "type": "string",
+      "minLength": 1,
+      "metadata": {
+        "description": "Complete learning plan url from SharePoint."
+      }
+    },
+    "newHireQuestionListName": {
+      "type": "string",
+      "minLength": 1,
+      "metadata": {
+        "description": "New hire question list name from SharePoint."
+      }
+    },
+    "newHireLearningPlansInWeeks": {
+      "type": "int",
+      "defaultValue": 4,
+      "metadata": {
+        "description": "New hire learning plan in weeks."
+      }
+    },
+    "cacheDurationInMinutes": {
+      "type": "int",
+      "defaultValue": 60,
+      "metadata": {
+        "description": "Number of minutes to cache user details in memory."
+      }
+    },
+    "delayInPairUpNotificationInDays": {
+      "type": "int",
+      "defaultValue": 1,
+      "metadata": {
+        "description": "Number of days to delay in pair up notification."
+      }
+    },
+    "newHireRetentionPeriodInDays": {
+      "type": "int",
+      "defaultValue": 60,
+      "metadata": {
+        "description": "Number of days for new hire retention period."
+      }
+    },
+    "securityGroup": {
+      "type": "string",
+      "minLength": 36,
+      "maxLength": 36,
+      "metadata": {
+        "description": "Security group Id (Required for user role)."
+      }
+    },
+    "tenantId": {
+      "type": "string",
+      "defaultValue": "[subscription().tenantId]",
+      "minLength": 1,
+      "maxLength": 36,
+      "metadata": {
+        "description": "The ID of the tenant to which the app will be deployed."
+      }
+    },
+    "sku": {
+      "type": "string",
+      "allowedValues": [
+        "Basic",
+        "Standard",
+        "Premium"
+      ],
+      "defaultValue": "Standard",
+      "metadata": {
+        "description": "The pricing tier for the hosting plan."
+      }
+    },
+    "planSize": {
+      "type": "string",
+      "allowedValues": [
+        "1",
+        "2",
+        "3"
+      ],
+      "defaultValue": "2",
+      "metadata": {
+        "description": "The size of the hosting plan (small, medium, or large)."
+      }
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Location for all resources."
+      }
+    },
+    "defaultCulture": {
+      "type": "string",
+      "minLength": 1,
+      "defaultValue": "en-US"
+    },
+    "gitRepoUrl": {
+      "type": "string",
+      "metadata": {
+        "description": "The URL to the GitHub repository to deploy."
+      },
+      "defaultValue": "https://github.com/OfficeDev/microsoft-teams-apps-newemployeeonboarding.git"
+    },
+    "gitBranch": {
+      "type": "string",
+      "metadata": {
+        "description": "The branch of the GitHub repository to deploy."
+      },
+      "defaultValue": "main"
+    }
+  },
+  "variables": {
+    "uniqueString": "[uniquestring(subscription().subscriptionId, resourceGroup().id, parameters('baseResourceName'))]",
+    "botName": "[parameters('baseResourceName')]",
+    "botAppName": "[parameters('baseResourceName')]",
+    "botAppDomain": "[concat(variables('botAppName'), '.azurewebsites.us')]",
+    "botAppUrl": "[concat('https://', variables('botAppDomain'))]",
+    "hostingPlanName": "[parameters('baseResourceName')]",
+    "storageAccountName": "[variables('uniqueString')]",
+    "botAppInsightsName": "[parameters('baseResourceName')]",
+    "keyVaultName": "[concat(variables('botAppName'), 'vault')]",
+    "keyVaultUrl": "[concat('https://',variables('keyVaultName'), '.vault.azure.us/secrets/')]",
+    "microsoftAppId": "MicrosoftAppId",
+    "microsoftAppPassword": "MicrosoftAppPassword",
+    "storageConnection": "StorageConnection",
+    "storageConnectionString": "core.usgovcloudapi.net",
+    "sharedSkus": [
+      "Free",
+      "Shared"
+    ],
+    "isSharedPlan": "[contains(variables('sharedSkus'), parameters('sku'))]",
+    "skuFamily": "[if(equals(parameters('sku'), 'Shared'), 'D', take(parameters('sku'), 1))]"
+  },
+  "resources": [
+    {
+      "apiVersion": "2018-02-01",
+      "kind": "Storage",
+      "location": "[parameters('location')]",
+      "name": "[variables('storageAccountName')]",
+      "sku": {
+        "name": "Standard_LRS"
+      },
+      "type": "Microsoft.Storage/storageAccounts"
+    },
+    {
+      "apiVersion": "2016-09-01",
+      "location": "[parameters('location')]",
+      "name": "[variables('hostingPlanName')]",
+      "properties": {
+        "name": "[variables('hostingPlanName')]",
+        "hostingEnvironment": "",
+        "numberOfWorkers": 1
+      },
+      "sku": {
+        "name": "[if(variables('isSharedPlan'), concat(variables('skuFamily'),'1'), concat(variables('skuFamily'),parameters('planSize')))]",
+        "tier": "[parameters('sku')]",
+        "size": "[concat(variables('skuFamily'), parameters('planSize'))]",
+        "family": "[variables('skuFamily')]",
+        "capacity": 0
+      },
+      "type": "Microsoft.Web/serverfarms"
+    },
+    {
+      "apiVersion": "2016-08-01",
+      "dependsOn": [
+        "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]",
+        "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]"
+      ],
+      "kind": "app",
+      "identity": {
+        "type": "SystemAssigned"
+      },
+      "location": "[parameters('location')]",
+      "name": "[variables('botAppName')]",
+      "properties": {
+        "name": "[variables('botAppName')]",
+        "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]",
+        "enabled": true,
+        "reserved": false,
+        "clientAffinityEnabled": true,
+        "clientCertEnabled": false,
+        "hostNamesDisabled": false,
+        "containerSize": 0,
+        "dailyMemoryTimeQuota": 0,
+        "httpsOnly": true,
+        "siteConfig": {
+          "alwaysOn": true,
+          "appsettings": [
+            {
+              "name": "SITE_ROLE",
+              "value": "bot"
+            },
+            {
+              "name": "Logging:LogLevel:Default",
+              "value": "Information"
+            },
+            {
+              "name": "ApplicationInsights:InstrumentationKey",
+              "value": ""
+            },
+            {
+              "name": "ApplicationInsights:LogLevel:Default",
+              "value": "Information"
+            },
+            {
+              "name": "ApplicationInsights:LogLevel:Microsoft",
+              "value": "Information"
+            },
+            {
+              "name": "MicrosoftAppId",
+              "value": ""
+            },
+            {
+              "name": "MicrosoftAppPassword",
+              "value": ""
+            },
+            {
+              "name": "App:AppBaseUri",
+              "value": "[concat('https://', variables('botAppDomain'))]"
+            },
+            {
+              "name": "App:TenantId",
+              "value": "[parameters('tenantId')]"
+            },
+            {
+              "name": "App:ConnectionName",
+              "value": "NewHireOnboardingAuth"
+            },
+            {
+              "name": "App:ManifestId",
+              "value": "[parameters('manifestId')]"
+            },
+            {
+              "name": "App:TeamsAppId",
+              "value": ""
+            },
+            {
+              "name": "App:HumanResourceTeamLink",
+              "value": "[parameters('humanResourceTeamLink')]"
+            },
+            {
+              "name": "Storage:ConnectionString",
+              "value": ""
+            },
+            {
+              "name": "i18n:DefaultCulture",
+              "value": "[parameters('defaultCulture')]"
+            },
+            {
+              "name": "i18n:SupportedCultures",
+              "value": "en-US"
+            },
+            {
+              "name": "WEBSITE_NODE_DEFAULT_VERSION",
+              "value": "12.18.0"
+            },
+            {
+              "name": "AzureAd:Instance",
+              "value": "https://login.microsoftonline.com/"
+            },
+            {
+              "name": "AzureAd:ApplicationIdURI",
+              "value": "[concat('api://', concat(variables('botAppDomain'), concat('/',parameters('botClientId'))))]"
+            },
+            {
+              "name": "AzureAd:ValidIssuers",
+              "value": "https://login.microsoftonline.com/TENANT_ID/v2.0,https://sts.windows.net/TENANT_ID/"
+            },
+            {
+              "name": "SharePoint:SiteName",
+              "value": "[parameters('siteName')]"
+            },
+            {
+              "name": "SharePoint:NewHireCheckListName",
+              "value": "[parameters('newHireCheckListName')]"
+            },
+            {
+              "name": "SharePoint:SiteTenantName",
+              "value": "[parameters('siteTenantName')]"
+            },
+            {
+              "name": "SharePoint:ShareFeedbackFormUrl",
+              "value": "[parameters('shareFeedbackFormUrl')]"
+            },
+            {
+              "name": "SharePoint:CompleteLearningPlanUrl",
+              "value": "[parameters('completeLearningPlanUrl')]"
+            },
+            {
+              "name": "SharePoint:NewHireQuestionListName",
+              "value": "[parameters('newHireQuestionListName')]"
+            },
+            {
+              "name": "SharePoint:NewHireLearningPlansInWeeks",
+              "value": "[parameters('newHireLearningPlansInWeeks')]"
+            },
+            {
+              "name": "SecurityGroup:Id",
+              "value": "[parameters('securityGroup')]"
+            },
+            {
+              "name": "Cache:CacheDurationInMinutes",
+              "value": "[parameters('cacheDurationInMinutes')]"
+            },
+            {
+              "name": "PairUpBackgroundService:DelayInPairUpNotificationInDays",
+              "value": "[parameters('delayInPairUpNotificationInDays')]"
+            },
+            {
+              "name": "PairUpBackgroundService:NewHireRetentionPeriodInDays",
+              "value": "[parameters('newHireRetentionPeriodInDays')]"
+            },
+            {
+              "name": "KeyVault:BaseUrl",
+              "value": "[variables('keyVaultUrl')]"
+            },
+            {
+              "name": "KeyVaultStrings:StorageConnection",
+              "value": "StorageConnection--SecretKey"
+            },
+            {
+              "name": "KeyVaultStrings:MicrosoftAppId",
+              "value": "MicrosoftAppId--SecretKey"
+            },
+            {
+              "name": "KeyVaultStrings:MicrosoftAppPassword",
+              "value": "MicrosoftAppPassword--SecretKey"
+            }
+          ],
+          "cors": {
+            "supportCredentials": true,
+            "allowedOrigins": [
+              "[concat('https://', variables('botAppDomain'))]"
+            ]
+          }
+        }
+      },
+      "resources": [
+        {
+          "apiVersion": "2016-08-01",
+          "name": "web",
+          "type": "sourcecontrols",
+          "condition": "[not(empty(parameters('gitRepoUrl')))]",
+          "dependsOn": [
+            "[resourceId('Microsoft.Web/sites', variables('botAppName'))]"
+          ],
+          "properties": {
+            "RepoUrl": "[parameters('gitRepoUrl')]",
+            "branch": "[parameters('gitBranch')]",
+            "IsManualIntegration": true
+          }
+        }
+      ],
+      "type": "Microsoft.Web/sites"
+    },
+    {
+      "type": "Microsoft.KeyVault/vaults",
+      "apiVersion": "2018-02-14",
+      "name": "[variables('keyVaultName')]",
+      "location": "[parameters('location')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Web/sites', variables('botAppName'))]"
+      ],
+      "tags": {
+        "displayName": "KeyVault"
+      },
+      "properties": {
+        "enabledForDeployment": "true",
+        "enabledForTemplateDeployment": "true",
+        "enabledForDiskEncryption": "true",
+        "tenantId": "[reference(concat('Microsoft.Web/sites/', variables('botAppName')), '2018-02-01', 'Full').identity.tenantId]",
+        "accessPolicies": [
+          {
+            "objectId": "[reference(concat('Microsoft.Web/sites/', variables('botAppName')), '2018-02-01', 'Full').identity.principalId]",
+            "tenantId": "[reference(concat('Microsoft.Web/sites/', variables('botAppName')), '2018-02-01', 'Full').identity.tenantId]",
+            "permissions": {
+              "secrets": [
+                "all"
+              ]
+            }
+          }
+        ],
+        "sku": {
+          "name": "Standard",
+          "family": "A"
+        },
+        "networkAcls": {
+          "value": {
+            "defaultAction": "Allow",
+            "bypass": "AzureServices"
+          }
+        }
+      }
+    },
+    {
+      "type": "Microsoft.KeyVault/vaults/secrets",
+      "apiVersion": "2018-02-14",
+      "name": "[concat(variables('keyVaultName'), '/', 'StorageConnection--SecretKey')]",
+      "location": "[parameters('location')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName'))]"
+      ],
+      "properties": {
+        "value": "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('storageAccountName'), ';AccountKey=', listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')),'2015-05-01-preview').key1,';EndpointSuffix=', variables('storageConnectionString'))]"
+      }
+    },
+    {
+      "type": "Microsoft.KeyVault/vaults/secrets",
+      "apiVersion": "2018-02-14",
+      "name": "[concat(variables('keyVaultName'), '/', 'MicrosoftAppId--SecretKey')]",
+      "location": "[parameters('location')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName'))]"
+      ],
+      "properties": {
+        "value": "[parameters('botClientId')]"
+      }
+    },
+    {
+      "type": "Microsoft.KeyVault/vaults/secrets",
+      "apiVersion": "2018-02-14",
+      "name": "[concat(variables('keyVaultName'), '/', 'MicrosoftAppPassword--SecretKey')]",
+      "location": "[parameters('location')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName'))]"
+      ],
+      "properties": {
+        "value": "[parameters('botClientSecret')]"
+      }
+    }
+  ],
+  "outputs": {
+    "botId": {
+      "type": "String",
+      "value": "[parameters('botClientId')]"
+    },
+    "appDomain": {
+      "type": "String",
+      "value": "[variables('botAppDomain')]"
+    }
+  }
+}


### PR DESCRIPTION
Added ARM templates for GCC hybrid deployments.
In hybrid setup, the Office 365 users and Microsoft Teams services are hosted in a different Azure AD tenant as the Azure resources. Also, both O365 and Azure use a Government Cloud:
- Office 365 with a GCC Azure AD tenant. Creating Bot channel registration in this tenant.
- Azure Government (https://portal.azure.us) associated to its GCC-H Azure AD tenant. Creating remaining resources in this tenant.